### PR TITLE
gems: Update nokogiri to 1.10.4 because of CVE-2019-5477.

### DIFF
--- a/common_cartridge_parser.gemspec
+++ b/common_cartridge_parser.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'sax-machine', '~> 1.3.2'
-  spec.add_dependency 'nokogiri', '~> 1.8.1'
+  spec.add_dependency 'nokogiri', '~> 1.10.4'
   spec.add_dependency 'rubyzip', '~> 1.2.1'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
specs are green locally.