### PR TITLE
MAE 61124 - Upgrade vulnerable dependencies in cms/m3

### DIFF
--- a/common_cartridge_parser.gemspec
+++ b/common_cartridge_parser.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'sax-machine', '~> 1.3.2'
-  spec.add_dependency 'nokogiri', '~> 1.12.5'
+  spec.add_dependency 'nokogiri', '~> 1.13.2'
   spec.add_dependency 'rubyzip', '~> 1.3.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Jira: https://vistahl.atlassian.net/browse/MAE-61124

- update nokogiri to 1.13.2