### PR TITLE
MAE-79325: Upgrade vulnerable dependencies in common_cartridge_parser.

### DIFF
--- a/common_cartridge_parser.gemspec
+++ b/common_cartridge_parser.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'sax-machine', '~> 1.3.2'
-  spec.add_dependency 'nokogiri', '~> 1.16.5'
+  spec.add_dependency 'nokogiri', '~> 1.18.8'
   spec.add_dependency 'rubyzip', '~> 1.3.0'
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
**JIRA link**: https://vistahl.atlassian.net/browse/MAE-79325

### Related PRs
- https://github.com/vhl/m3/pull/13117
- https://github.com/vhl/mae/pull/4250